### PR TITLE
Corrected some out of date dependencies to allow users to avoid errors when getting started with React projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.1",
     "reactstrap": "^9.1.4",
-    "typescript": "^5.0.4"
+    "typescript": "^4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,4 @@
-import { OidcConfiguration } from "@axa-fr/react-oidc/dist/vanilla/types"
+import { OidcConfiguration } from "@axa-fr/react-oidc"
 
 const oidcConfig: OidcConfiguration = {
     client_id: process.env.REACT_APP_SSO_CLIENT_ID ?? 'test',


### PR DESCRIPTION
Fixes the following errors: 

```shell
While resolving: react-scripts@5.0.1
Found: typescript@5.4.3
node_modules/typescript
  typescript@"^5.0.4" from the root project
Could not resolve dependency:
peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
node_modules/react-scripts
  react-scripts@"^5.0.1" from the root project
Conflicting peer dependency: typescript@4.9.5
node_modules/typescript
  peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
  node_modules/react-scripts
    react-scripts@"^5.0.1" from the root project
```

```shell
ERROR in src/configuration.ts:1:35
TS2307: Cannot find module '@axa-fr/react-oidc/dist/vanilla/types' or its corresponding type declarations.
  > 1 | import { OidcConfiguration } from "@axa-fr/react-oidc/dist/vanilla/types"
      |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    2 |
    3 | const oidcConfig: OidcConfiguration = {
    4 |     client_id: process.env.REACT_APP_SSO_CLIENT_ID ?? 'test',
```